### PR TITLE
fix: remove display options that were conflicting with other fields with the same name in other operations, causing errors when using expressions

### DIFF
--- a/nodes/Pipefy/actions/card/create.operation.ts
+++ b/nodes/Pipefy/actions/card/create.operation.ts
@@ -16,7 +16,8 @@ const properties: INodeProperties[] = [
 		type: 'options',
 		default: '',
 		required: true,
-		description: 'The ID of the organization to get the pipes from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		description:
+			'The ID of the organization to get the pipes from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 		typeOptions: {
 			loadOptionsMethod: 'getOrgs',
 		},
@@ -27,21 +28,11 @@ const properties: INodeProperties[] = [
 		type: 'options',
 		default: '',
 		required: true,
-		description: 'The ID of the pipe to get the cards from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		description:
+			'The ID of the pipe to get the cards from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 		typeOptions: {
 			loadOptionsMethod: 'getOrgPipes',
 			loadOptionsDependsOn: ['orgId'],
-		},
-		displayOptions: {
-			show: {
-				orgId: [
-					{
-						_cnd: {
-							gt: 0,
-						},
-					},
-				],
-			},
 		},
 	},
 	{
@@ -51,17 +42,6 @@ const properties: INodeProperties[] = [
 		default: '',
 		required: true,
 		hint: 'The title of the new card',
-		displayOptions: {
-			show: {
-				pipeId: [
-					{
-						_cnd: {
-							gt: 0,
-						},
-					},
-				],
-			},
-		},
 	},
 	{
 		displayName: 'Fields',

--- a/nodes/Pipefy/actions/card/move.operation.ts
+++ b/nodes/Pipefy/actions/card/move.operation.ts
@@ -27,22 +27,12 @@ const properties: INodeProperties[] = [
 		name: 'phaseId',
 		default: '',
 		required: true,
-		description: 'The ID of the phase to move. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		description:
+			'The ID of the phase to move. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 		type: 'options',
 		typeOptions: {
 			loadOptionsMethod: 'getPipePhases',
 			loadOptionsDependsOn: ['cardId'],
-		},
-		displayOptions: {
-			show: {
-				cardId: [
-					{
-						_cnd: {
-							gt: constants.cardIdLength,
-						},
-					},
-				],
-			},
 		},
 	},
 ];

--- a/nodes/Pipefy/actions/card/updateFields.operation.ts
+++ b/nodes/Pipefy/actions/card/updateFields.operation.ts
@@ -17,7 +17,8 @@ const properties: INodeProperties[] = [
 		default: '',
 		required: true,
 		hint: 'The ID of the card to update the fields of',
-		description: 'You can find the card\'s ID in the URL when you\'re viewing it in the browser. https://app.pipefy.com/open-cards/[ID].',
+		description:
+			"You can find the card's ID in the URL when you're viewing it in the browser. https://app.pipefy.com/open-cards/[ID].",
 		type: 'string',
 		typeOptions: {
 			minValue: constants.cardIdLength,
@@ -29,22 +30,12 @@ const properties: INodeProperties[] = [
 		name: 'phaseId',
 		default: '',
 		required: true,
-		description: 'The ID of the phase to move. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		description:
+			'The ID of the phase to move. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 		type: 'options',
 		typeOptions: {
 			loadOptionsMethod: 'getPipePhases',
 			loadOptionsDependsOn: ['cardId'],
-		},
-		displayOptions: {
-			show: {
-				cardId: [
-					{
-						_cnd: {
-							gt: constants.cardIdLength,
-						},
-					},
-				],
-			},
 		},
 	},
 	{
@@ -62,12 +53,14 @@ const properties: INodeProperties[] = [
 			{
 				name: 'Add',
 				value: 'add',
-				description: 'Append values to existing list of values, compatible with field types that support lists like Attachments, Assignees, Labels, Connections and Checklists',
+				description:
+					'Append values to existing list of values, compatible with field types that support lists like Attachments, Assignees, Labels, Connections and Checklists',
 			},
 			{
 				name: 'Remove',
 				value: 'remove',
-				description: 'Remove values from the existing list of values, compatible with field types that support lists like Attachments, Assignees, Labels, Connections and Checklists',
+				description:
+					'Remove values from the existing list of values, compatible with field types that support lists like Attachments, Assignees, Labels, Connections and Checklists',
 			},
 		],
 		required: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Improvements
  - Pipefy Card Create: “Pipe Name or ID” and “Title” fields are now always visible.
  - Pipefy Card Move: “Phase ID” field is now always visible.
  - Pipefy Card Update Fields: “Phase Name or ID” field is now always visible; existing gating for “Fields” remains unchanged.

- Style
  - Reformatted several field descriptions to multi-line for readability; no semantic changes.

- Notes
  - No changes to underlying logic or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->